### PR TITLE
Add eigen 3.2.x support + Fix some warnings.

### DIFF
--- a/exe/conic_simplification.cpp
+++ b/exe/conic_simplification.cpp
@@ -37,7 +37,7 @@ bool checkColumn( const Eigen::MatrixBase<D>& A,
 		  const Eigen::MatrixBase<D>& B,
 		  const int index, int sign = +1 )
 {
-  const int NC = A.rows(),NA=A.cols(),NB=B.cols(), NX = NA+NB;
+  const int NC = (int)A.rows(),NA=(int)A.cols(),NB=(int)B.cols(), NX = (int)(NA+NB);
 
   std::vector<Eigen::MatrixXd> J(3);
   std::vector<soth::VectorBound> b(3);
@@ -98,7 +98,7 @@ int checkAndModify( SubMatrix<MatrixXd,ColPermutation> &A,
     }
   if( checkColumn(A,B,index,-1) )
     {
-      int ref = A.removeCol(index);
+      int ref = (int)A.removeCol(index);
       B.pushColFront(ref);
       cout << "transfert ... "<< endl;
       return 0;
@@ -116,7 +116,7 @@ bool checkOut( const MatrixXd &X,
   /* shoot ab = rand, with a>0 and target=AB*ab
    * solve X*x=target, with x>0. */
 
-  const int NC = A.rows(),NA=A.cols(),NB=B.cols(), NX = X.cols();
+  const int NC = (int)A.rows(), NA=(int)A.cols(),NB=(int)B.cols(), NX = (int)X.cols();
   VectorXd ab = VectorXd::Random(NA+NB); ab.head(NA)+= VectorXd::Ones(NA); ab.head(NA)/=2;
   VectorXd target = A*ab.head(NA)+B*ab.tail(NB);
   cout << "ab = " << (MATLAB)ab << endl;
@@ -162,7 +162,7 @@ bool checkIn( const MatrixXd &X,
   /* shoot x = rand>0, and target=X*x
    * solve Aa+Bb = x, with a>0. */
 
-  const int NC = A.rows(),NA=A.cols(),NB=B.cols(), NX = X.cols();
+  const int NC = (int)A.rows(),NA=(int)A.cols(),NB=(int)B.cols(), NX =(int) X.cols();
   VectorXd x = VectorXd::Random(NX); x+= VectorXd::Ones(NX); x/=2;
   VectorXd target = X*x;
   cout << "x = " << (MATLAB)x << endl;
@@ -201,7 +201,7 @@ bool checkIn( const MatrixXd &X,
 
 
 
-int main (int argc, char** argv)
+int main (int , char** )
 {
 # ifndef NDEBUG
   sotDebugTrace::openFile();

--- a/exe/simple.cpp
+++ b/exe/simple.cpp
@@ -55,7 +55,7 @@ int main ()
   std::vector<soth::VectorBound> b;
 
   soth::Random::setSeed(704819);
-  const int size = 100; 
+  //  const int size = 100; 
 
   //generateFixedSizeRandomProfile(size,
   //                               1,0.99,0.99,NB_STAGE,RANKFREE,RANKLINKED,NR,NC);
@@ -79,7 +79,7 @@ int main ()
     {
       RANKFREE += 6,3,7,2,5,5,44,6,2,4,5,3,7,1,50;
       RANKLINKED.resize(RANKFREE.size(),0);
-      NB_STAGE = RANKFREE.size();
+      NB_STAGE = (unsigned int)RANKFREE.size();
       NR = RANKFREE;
       NC = 150;
     }
@@ -87,7 +87,7 @@ int main ()
   std::cout << "nVar \t= " << NC << std::endl;
   std::cout << "nLevels \t= " << NB_STAGE << std::endl;
   std::cout << "LevelDim \t= [ ";
-  for(int i=0;i<NB_STAGE;++i) std::cout << NR[i] << " ";
+  for(int i=0;i<(int)NB_STAGE;++i) std::cout << NR[i] << " ";
   std::cout << "]" << std::endl;
 
   generateDeficientDataSet(J,b,NB_STAGE,RANKFREE,RANKLINKED,NR,NC);
@@ -109,7 +109,7 @@ int main ()
   gettimeofday(&t0,NULL);
   for(int i=0;i<1000;++i) ehqp(hsolver);
   gettimeofday(&t1,NULL);
-  time = (t1.tv_sec-t0.tv_sec)+(t1.tv_usec-t0.tv_usec)/1.0e6;
+  time = (double)(t1.tv_sec-t0.tv_sec)+(double)(t1.tv_usec-t0.tv_usec)/1.0e6;
   cout << "ehqp = " << time << " ms " << std::endl;
 
 
@@ -121,7 +121,7 @@ int main ()
     Eigen::DestructiveColPivQR<MatrixXd,MatrixXd > mQR(A,Y, 1e-6);
   //Eigen::DestructiveColPivQR<SubMatrixXd,MatrixXd > mQR(Ar,Y, 1e-6);
   gettimeofday(&t1,NULL);
-  time = (t1.tv_sec-t0.tv_sec)+(t1.tv_usec-t0.tv_usec)/1.0e6;
+  time = (double)(t1.tv_sec-t0.tv_sec)+(double)(t1.tv_usec-t0.tv_usec)/1.0e6;
   cout << "qr = " << time << " ms " << std::endl;
 
 

--- a/src/ActiveSet.cpp
+++ b/src/ActiveSet.cpp
@@ -65,7 +65,7 @@ namespace soth
   activeRow( unsigned int ref, Bound::bound_t type )
   {
     const unsigned int row = getAFreeRow();
-    assert( (row>=0)&&(row<size()) );
+    assert( row<size() );
     active( ref,type,row );
     return row;
   }

--- a/src/ActiveSet.hpp
+++ b/src/ActiveSet.hpp
@@ -44,7 +44,7 @@ namespace soth
   public: /* --- Accessors --- */
     /* Return the number of active constraint. */
     inline unsigned int   nbActive( void ) const { return nba; }
-    inline unsigned int   size( void ) const { return cstMap.size(); }
+    inline unsigned int   size( void ) const { return (unsigned int)cstMap.size(); }
     bool                  isFreezed( unsigned int ref ) const;
     bool                  isActive( unsigned int ref ) const;
     bool                  wasActive( unsigned int ref,const Bound::bound_t type ) const;

--- a/src/Algebra.hpp
+++ b/src/Algebra.hpp
@@ -66,8 +66,8 @@ namespace soth
   template< typename Derived >
   void MATLAB::genericInit( const MatrixBase<Derived> & m1 )
   {
-    if( m1.rows()==0 ) initMatrixRowNull( m1.cols() );
-    else if( m1.cols()==0 ) initMatrixColNull( m1.rows() );
+    if( m1.rows()==0 ) initMatrixRowNull( (unsigned int)m1.cols() );
+    else if( m1.cols()==0 ) initMatrixColNull( (unsigned int)m1.rows() );
     else if( m1.IsVectorAtCompileTime)
       {
 	if( m1.cols()==1 ) initVector( m1.col(0) );
@@ -91,7 +91,7 @@ namespace soth
 	  if( m1.size()!=i+1 )
 	    {
 	      ostmp << ",";
-	      const int size = ostmp.str().length();
+	      const int size = (int)ostmp.str().length();
 	      for( unsigned int i=size;i<8;++i) ostmp<<" ";
 	      ostmp << "\t";
 	    }
@@ -138,7 +138,7 @@ namespace soth
 	      if( m1.cols()!=j+1 )
 		{
 		  ostmp << ",";
-		  const int size = ostmp.str().length();
+		  const int size = (int)ostmp.str().length();
 		  for( unsigned int i=size;i<8;++i) ostmp<<" ";
 		  ostmp << "\t";
 		}

--- a/src/BasicStage.cpp
+++ b/src/BasicStage.cpp
@@ -54,7 +54,7 @@ namespace soth
     ,boundsMap( inbounds.data(),inbounds.size(),1)
 
     ,J( Jmap ), bounds( boundsMap )
-    ,nr( inJ.rows() ), nc( inJ.cols() )
+    ,nr( (unsigned int)inJ.rows() ), nc( (unsigned int)inJ.cols() )
 
     ,Y(inY)
   {

--- a/src/HCOD.cpp
+++ b/src/HCOD.cpp
@@ -130,7 +130,7 @@ namespace soth
   {
     int r=0;
     for (size_t i=0; i<stages.size(); ++i)
-      r+= stages[i]->rank();
+      r+= (int) stages[i]->rank();
     return r;
   }
 

--- a/src/HCOD.hpp
+++ b/src/HCOD.hpp
@@ -47,7 +47,7 @@ namespace soth
     //sizes
     int sizeA() const;
     int rank() const;
-    unsigned int nbStages() const { return stages.size(); }
+    unsigned int nbStages() const { return (unsigned int)stages.size(); }
 
     /* --- Decomposition --- */
   public:

--- a/src/Stage.cpp
+++ b/src/Stage.cpp
@@ -133,7 +133,7 @@ namespace soth
   }
 
   cstref_vector_t Stage::
-  getOptimalActiveSet( bool withTwin )
+  getOptimalActiveSet( bool  )
   {
     cstref_vector_t res(sizeA());
     int loop=0;
@@ -235,7 +235,7 @@ namespace soth
     /* Compute ML=J(initIr,:)*Y. */
     computeInitialJY();
     assert( Yinit.getRank() >= 0 && Yinit.getRank()<=(int)nc );
-    const unsigned int previousRank = Y.getRank();
+    const unsigned int previousRank = (unsigned int)Y.getRank();
 
     isWIdenty = true;
 
@@ -292,7 +292,7 @@ namespace soth
      * sizeL = mQR.rank();
      */
     assert( mQR.rank()>=0 && mQR.rank()<=int(sizeL) );
-    const unsigned int rank = mQR.rank();
+    const unsigned int rank = (unsigned int)mQR.rank();
 
     conditionalWinit( sizeL==rank );
     while( sizeL>rank )
@@ -344,13 +344,13 @@ namespace soth
     const Index r = (in_r<0)?row-1:in_r;
     for( Index i=r-1;i>=0;--i )               // PSEUDOZEROS
       {
-	Givens G1(L.col(i),i,row);
+	Givens G1(L.col(i),(int)i,(int)row);
 
 	G1.applyTransposeOnTheRight(Mr);
-	G1.applyTransposeOnTheRight(L,r);
+	G1.applyTransposeOnTheRight(L,(int)r);
 	G1.applyThisOnTheLeft(Wr);
       }
-    removeARowFromL( row );
+    removeARowFromL((unsigned int)row );
 
     sotDEBUG(15) << "W = " << MATLAB(W,isWIdenty) << std::endl;
     sotDEBUG(15) << "L = " << (MATLAB)L << std::endl;
@@ -387,7 +387,8 @@ namespace soth
       {
 	if( std::abs(lambda[i])>EPSILON )
 	  {
-	    const unsigned int cstref = activeSet.mapInv(i);
+	    const unsigned int cstref = (unsigned int)
+	      activeSet.mapInv((unsigned int)i);
 	    if(! activeSet.isFreezed(cstref) )
 	      {
 		activeSet.freeze(cstref);
@@ -529,7 +530,7 @@ namespace soth
     sotDEBUG(5) << "W0 = " << MATLAB(W,isWIdenty) << std::endl;
     sotDEBUG(5) << "M0 = " << (MATLAB)M << std::endl;
     sotDEBUG(5) << "L0 = " << (MATLAB)L << std::endl;
-    L.pushColFront( M.popColBack() );
+    L.pushColFront( (int) M.popColBack() );
     sizeM--;
 
     /* Check if one of the M's grown. */
@@ -544,7 +545,7 @@ namespace soth
 	    Block<MatrixXd> ML(ML_,0,0,nr,sizeM+1);
 	    for( Index j=i+1;j<sizeN();++j )  // PSEUDOZERO
 	      {
-		Givens G1( Ln,i,j );
+		Givens G1( Ln,(int)i,(int)j );
 		G1.transpose() >> M;
 		G1.transpose() >> Ln;
 		W << G1;
@@ -631,7 +632,7 @@ namespace soth
     const int rowRankInL = col-sizeN();
 
     activeSet.unactiveRow(row);
-    const unsigned int wcoldown = W.removeCol(col);
+    const unsigned int wcoldown = (unsigned int)W.removeCol(col);
     if( rowRankInL>=0 ) { L.removeRow(rowRankInL); sizeL--; }
     freeML.put(wcoldown);
 
@@ -711,7 +712,7 @@ namespace soth
 
     /* Choose the first available row in ML. */
     const unsigned int wcolup = freeML.get();
-    assert( (wcolup >= 0)&&(wcolup<nr) );
+    assert( wcolup<nr );
     sotDEBUG(5) << " wc=" << wcolup << endl;
 
     /* Add a line to ML. */
@@ -728,7 +729,7 @@ namespace soth
 	if( norm2>EPSILON*EPSILON )
 	  {
 	    sotDEBUG(45) << "Oversize value is x"<<i<<" = " << JupY(i)<<std::endl;
-	    rankJ=i+1;
+	    rankJ=(unsigned int)i+1;
 	    break;
 	  }
       }
@@ -738,7 +739,7 @@ namespace soth
       { /* Rank increase: remove the tail of JuY. */
 	for( Index i=rankJ-1;i>int(sizeM+sizeL);--i )
 	  {
-	    Givens G1(JupY,i-1,i,true);
+	    Givens G1(JupY,(int)i-1,(int)i,true);
 	    Yup.push(G1);
 	  }
 	addARow(wcolup);
@@ -1394,7 +1395,8 @@ namespace soth
     bool res=false;
     EI_FOREACH( i,lambda )
       {
-	const unsigned int cstref = activeSet.mapInv(i);
+	const unsigned int cstref = (unsigned int)
+	  activeSet.mapInv((unsigned int)i);
 	Bound::bound_t btype = activeSet.whichBound(cstref);
 
 	if( activeSet.isFreezed(cstref) ) continue;
@@ -1403,7 +1405,8 @@ namespace soth
 	  case Bound::BOUND_TWIN:
 	    break; // Nothing to do.
 	  case Bound::BOUND_SUP:
-	    sotDEBUG(5) << name<<": row"<<i<<", cst"<<which(i) << ": l=" << lambda(i,0) << endl;
+	    sotDEBUG(5) << name<<": row"<<i<<", cst"<<which((unsigned int)i) 
+			<< ": l=" << lambda(i,0) << endl;
 	    if( -lambda[i]>lmax )
 	      {
 		// double Ju = J.row(cstref)*u;
@@ -1411,12 +1414,13 @@ namespace soth
 		  {
 		    res=true;
 		    lmax=-lambda[i];
-		    row=i;
+		    row=(unsigned int)i;
 		  }
 	      }
 	    break;
 	  case Bound::BOUND_INF:
-	    sotDEBUG(5) << name<<": row"<<i<<", cst"<<which(i) << ": l=" << lambda(i,0) << endl;
+	    sotDEBUG(5) << name<<": row"<<i<<", cst"<<which((unsigned int)i) 
+			<< ": l=" << lambda(i,0) << endl;
 	    if( -lambda[i]>lmax ) // TODO: change the sign of the bound-inf cst.
 	      {
 		// double Ju = J.row(cstref)*u;
@@ -1424,7 +1428,7 @@ namespace soth
 		  {
 		    res=true;
 		    lmax=-lambda[i];
-		    row=i;
+		    row=(unsigned int)i;
 		  }
 	      }
 	    break;

--- a/src/Stage.hpp
+++ b/src/Stage.hpp
@@ -243,7 +243,7 @@ namespace soth
     inline unsigned int nbConstraints( void ) const { return nr; }
     inline unsigned int sizeA( void ) const { return activeSet.nbActive(); }
     // sizeN = card(In) = sizeA-sizeL.
-    inline int sizeN( void ) const { assert((int)sizeA()-sizeL>=0);return sizeA()-sizeL; }
+    inline int sizeN( void ) const { assert((int)(sizeA()-sizeL)>=0);return sizeA()-sizeL; }
     inline Index rank() const {return sizeL;}
 
     inline int getSizeM() const { return sizeM; }

--- a/src/SubMatrix.hpp
+++ b/src/SubMatrix.hpp
@@ -56,11 +56,11 @@ namespace Eigen
     {
       Index size = high-low;
       if (size>1)
-	return VectorType::LinSpaced(size, low, high-1);
+	return VectorType::LinSpaced((int)size, (int)low, (int)high-1);
       else if (size==0)
 	return VectorType();
       else
-	return VectorType::Constant(1,low);
+	return VectorType::Constant(1,(int)low);
     }
   };
 
@@ -218,7 +218,7 @@ namespace Eigen
       eigen_assert(j>=0 && j<rows());
       Index tmp = rowIndices[i];
       rowIndices[i] = rowIndices[j];
-      rowIndices[j] = tmp;
+      rowIndices[j] = (int) tmp;
     }
     void pushRowFront(Index index)
     {
@@ -227,14 +227,14 @@ namespace Eigen
       rowIndices.conservativeResize(s+1);
       /* Cannot use block for this operation. */
       for (Index i=s; i>0; --i) {rowIndices[i]=rowIndices[i-1];}
-      rowIndices[0] = index;
+      rowIndices[0] = (int)index;
     }
     void pushRowBack(Index index)
     {
       eigen_assert( inMRange(index) );
       const Index s = rows();
       rowIndices.conservativeResize(s+1);
-      rowIndices[s] = index;
+      rowIndices[s] = (int)index;
     }
     Index removeRow(Index index)
     {
@@ -363,7 +363,7 @@ namespace Eigen
       eigen_assert(j>=0 && j<cols());
       Index tmp = colIndices[i];
       colIndices[i] = colIndices[j];
-      colIndices[j] = tmp;
+      colIndices[j] = (int)tmp;
     }
     void pushColFront(Index index)
     {
@@ -371,14 +371,14 @@ namespace Eigen
       const Index s = cols();
       colIndices.conservativeResize(s+1);
       for (Index i=s; i>0; --i) {colIndices[i]=colIndices[i-1];}
-      colIndices[0] = index;
+      colIndices[0] = (int)index;
     }
     void pushColBack(Index index)
     {
       eigen_assert( inMRange(index) );
       const Index s = cols();
       colIndices.conservativeResize(s+1);
-      colIndices[s] = index;
+      colIndices[s] = (int) index;
     }
     Index removeCol(Index index)
     {

--- a/src/solvers.hpp
+++ b/src/solvers.hpp
@@ -22,7 +22,7 @@ namespace soth
     assert(lhs.rows() == lhs.cols());
     assert(lhs.rows() > 0);
     assert(rhs.size() == lhs.rows());
-    const int n = lhs.rows();
+    const int n = (int)lhs.rows();
     for (int i=0; i<n-1; ++i)
     {
       rhs[i] /= lhs(i,i);
@@ -47,7 +47,7 @@ namespace soth
     assert(lhs.rows() == lhs.cols());
     assert(lhs.rows() > 0);
     assert(rhs.size() == lhs.rows());
-    const int n = lhs.rows();
+    const int n = (int)lhs.rows();
     for (int i=n-1; i>0; --i)
     {
       rhs[i] /= lhs(i,i);

--- a/unitTesting/COD.hpp
+++ b/unitTesting/COD.hpp
@@ -78,7 +78,7 @@ namespace soth
 
     void compute( const MatrixXd& A,  const int rank_=-1, const double EPSILON=1e-8 )
     {
-      NC=A.cols(); NR=A.rows();
+      NC=(int)A.cols(); NR=(int)A.rows();
 #ifdef DEBUG
       Ainit=A;
 #endif

--- a/unitTesting/tbasic.cpp
+++ b/unitTesting/tbasic.cpp
@@ -20,7 +20,7 @@ void testBasicStage()
 {
   MatrixXd m1(5,4);
   Map<MatrixXd> map1(m1.data(), m1.size(), 1);
-  map1 = VectorXd::LinSpaced(m1.size(), 0, m1.size()-1);
+  map1 = VectorXd::LinSpaced((long int)m1.size(), 0.0, (double)m1.size()-1);
   std::cout << "m1 = " << m1 << endl;
 
   VectorBound b1(5);

--- a/unitTesting/tchrono.cpp
+++ b/unitTesting/tchrono.cpp
@@ -37,7 +37,8 @@ namespace soth
   };
   double operator-( const Now& t1, const Now& t0 )
   {
-    return (t1.sec-t0.sec)*1000.0 + (t1.usec-t0.usec+0.0)/1000.0;
+    return ((double)(t1.sec-t0.sec))*1000.0 + 
+      ((double)(t1.usec-t0.usec)+0.0)/1000.0;
   }
   std::ostream& operator<< (std::ostream& os,const Now& now )
   { return os << now.sec <<"' " << now.usec;  }
@@ -95,7 +96,7 @@ int main (int argc, char** argv)
       /* Initialize the seed. */
       struct timeval tv;
       gettimeofday(&tv,NULL);
-      int seed = tv.tv_usec % 7919; //= 7594;
+      int seed = (int)(tv.tv_usec % 7919); //= 7594;
       if( argc == 2 )
 	{  seed = atoi(argv[1]);  }
       std::cout << "seed = " << seed << std::endl;

--- a/unitTesting/tcod.cpp
+++ b/unitTesting/tcod.cpp
@@ -60,14 +60,15 @@ int main ( void )
 	gettimeofday(&t0,NULL);
 	COD Acod; Acod.compute(A,RANK);
 	gettimeofday(&t1,NULL);
-	double time = (t1.tv_sec-t0.tv_sec)+(t1.tv_usec-t0.tv_usec)/1.0e6;
+	double time = (double)(t1.tv_sec-t0.tv_sec)+(double)(t1.tv_usec-t0.tv_usec)/1.0e6;
 	totalTime += time;
 
 	gettimeofday(&t0,NULL);
 	//JacobiSVD<MatrixXd> Asvd(A, ComputeThinU | ComputeThinV);
 	gettimeofday(&t1,NULL);
 
-	double timeSVD = (t1.tv_sec-t0.tv_sec)+(t1.tv_usec-t0.tv_usec)/1.0e6;
+	double timeSVD = (double)(t1.tv_sec-t0.tv_sec)+
+	  (double)(t1.tv_usec-t0.tv_usec)/1.0e6;
 	totalTimeSVD += timeSVD;
 	if(! (shoot%100)) std::cout <<  time*1000 <<  "\t" << timeSVD*1000 << std::endl;
       }

--- a/unitTesting/tdump_problem.cpp
+++ b/unitTesting/tdump_problem.cpp
@@ -48,7 +48,7 @@ int main (int argc, char** argv)
     struct timeval tv;
     gettimeofday(&tv,NULL);
 
-    int seed = tv.tv_usec % 7919; //= 7594;
+    int seed = (int)(tv.tv_usec % 7919); //= 7594;
     if( argc == 2 )
       {  seed = atoi(argv[1]);  }
     std::cout << "seed = " << seed << std::endl;

--- a/unitTesting/tgivens.cpp
+++ b/unitTesting/tgivens.cpp
@@ -43,7 +43,7 @@ void testSimpleGivens()
 
   const double n1 = M.row(0).tail( M.cols()-1).norm(); UNUSED(n1);
   sotDEBUG(1) << endl << "Nullify row 0 ..." << endl;
-  for (int i=M.cols()-1; i>1; --i)
+  for (int i=(int)M.cols()-1; i>1; --i)
   {
     //Givens G(M.row(0), i-1, i);
     M<<Givens(M.row(0), i-1, i);
@@ -90,7 +90,7 @@ void testSubMatrixGivens()
 
   const double n1 = M.row(0).tail( M.cols()-1).norm(); UNUSED(n1);
   sotDEBUG(1) << endl << "Nullify row 0 ..." << endl;
-  for (int i=M.cols()-1; i>1; --i)
+  for (int i=(int)M.cols()-1; i>1; --i)
   {
     M<<Givens(M.row(0), i-1, i);
     //Givens (M.row(0), i-1, i).applyThisOnTheLeft(M);
@@ -134,7 +134,7 @@ void testSequenceSub()
   U.push(G3);
 
   Givens Gr;
-  for (int i=M.cols()-1; i>1; --i)
+  for (int i=(int)M.cols()-1; i>1; --i)
   {
     Gr.makeGivens(M.row(0), i-1, i); Gr.applyThisOnTheLeft(M);
     V.push(Gr);

--- a/unitTesting/thcod_full.cpp
+++ b/unitTesting/thcod_full.cpp
@@ -104,7 +104,7 @@ clearIteralively( soth::HCOD& hcod )
 
 
 
-int main (int argc, char** argv)
+int main (int , char** )
 {
   bool exitOk=true;
   const int executeAll = 1;
@@ -118,7 +118,7 @@ int main (int argc, char** argv)
   {
     struct timeval tv;
     gettimeofday(&tv,NULL);
-    int seed = tv.tv_usec % 7919;
+    int seed = (int)(tv.tv_usec % 7919);
     std::cout << "seed = " << seed << std::endl;
     soth::Random::setSeed(seed);
   }
@@ -265,7 +265,10 @@ int main (int argc, char** argv)
     exitOk&=hcod.testRecomposition(&std::cout);
     //if( sotDEBUGFLOW.outputbuffer.good() ) hcod.show( sotDEBUGFLOW.outputbuffer );
 
-    int rank=hcod.rank();
+    #ifndef NDEBUG  
+    int rank=hcod.rank(); 
+    #endif
+
     for( int i=0;i<NB_STAGE;++i )
       {
 	hcod.update( i,ConstraintRef(2,soth::Bound::BOUND_INF) );
@@ -299,10 +302,15 @@ int main (int argc, char** argv)
     exitOk&=hcod.testRecomposition(&std::cout);
     //if( sotDEBUGFLOW.outputbuffer.good() ) hcod.show( sotDEBUGFLOW.outputbuffer );
 
+    #ifndef NDEBUG
     int rank=hcod.rank();
+    #endif
+
     for( int i=0;i<NB_STAGE;++i )
       {
-	const int rankStage = hcod[i].rank();
+	#ifndef NDEBUG
+        const int rankStage = (int) hcod[i].rank();
+	#endif
 	hcod.update( i,ConstraintRef(2,soth::Bound::BOUND_INF) );
 	exitOk&=hcod.testRecomposition(&std::cout);
 	assert( hcod.rank()==rank );
@@ -349,11 +357,15 @@ int main (int argc, char** argv)
 
     exitOk&=hcod.testRecomposition(&std::cout);
     //if( sotDEBUGFLOW.outputbuffer.good() ) hcod.show( sotDEBUGFLOW.outputbuffer );
-
+    
+    #ifndef NDEBUG
     int rank=hcod.rank();
+    #endif
     for( int i=0;i<NB_STAGE-1;++i )
       {
-	const int rankStage = hcod[i].rank();
+        #ifndef NDEBUG
+        const int rankStage = (int)hcod[i].rank();
+        #endif
 	hcod.update( i,ConstraintRef(2,soth::Bound::BOUND_INF) );
 	exitOk&=hcod.testRecomposition(&std::cout);
 	assert( hcod.rank()==rank );
@@ -389,8 +401,10 @@ int main (int argc, char** argv)
     exitOk&=hcod.testRecomposition(&std::cout);
     //if( sotDEBUGFLOW.outputbuffer.good() ) hcod.show( sotDEBUGFLOW.outputbuffer );
 
+    #ifndef NDEBUG
     const int rank=hcod.rank();
-    const int rankStage = hcod[LS].rank();
+    const int rankStage = (int)hcod[LS].rank();
+    #endif
     assert(rank==NC);
     hcod.update( LS,ConstraintRef(LR,soth::Bound::BOUND_INF) );
     exitOk&=hcod.testRecomposition(&std::cout);
@@ -424,9 +438,10 @@ int main (int argc, char** argv)
 
     exitOk&=hcod.testRecomposition(&std::cout);
     //if( sotDEBUGFLOW.outputbuffer.good() ) hcod.show( sotDEBUGFLOW.outputbuffer );
-
-    const int rank=hcod.rank();
-    const int rankStage = hcod[LS].rank();
+    #ifndef NDEBUG
+    const int rank=(int)hcod.rank();
+    const int rankStage = (int)hcod[LS].rank();
+    #endif
     assert(rank==NC);
     hcod.update( LS,ConstraintRef(LR,soth::Bound::BOUND_INF) );
     exitOk&=hcod.testRecomposition(&std::cout);
@@ -603,11 +618,14 @@ int main (int argc, char** argv)
 
     exitOk&=hcod.testRecomposition(&std::cout);
     //if( sotDEBUGFLOW.outputbuffer.good() ) hcod.show( sotDEBUGFLOW.outputbuffer );
-
+    #ifndef NDEBUG
     int rank=hcod.rank();
+    #endif
     for( int i=0;i<NB_STAGE;++i )
       {
-	const int rankStage = hcod[i].rank();
+        #ifndef NDEBUG
+	const int rankStage = (int)hcod[i].rank();
+        #endif
  	hcod.downdate( i,1 );
 	exitOk&=hcod.testRecomposition(&std::cout);
 	assert( hcod.rank()==--rank );
@@ -639,11 +657,14 @@ int main (int argc, char** argv)
 
     exitOk&=hcod.testRecomposition(&std::cout);
     //if( sotDEBUGFLOW.outputbuffer.good() ) hcod.show( sotDEBUGFLOW.outputbuffer );
-
+    #ifndef NDEBUG
     int rank=hcod.rank();
+    #endif
     for( int i=0;i<NB_STAGE;++i )
       {
-	const int rankStage = hcod[i].rank();
+        #ifndef NDEBUG
+	const int rankStage = (int)hcod[i].rank();
+	#endif
  	hcod.downdate( i,1 );
 	exitOk&=hcod.testRecomposition(&std::cout);
 	assert( hcod.rank()==rank );
@@ -690,13 +711,13 @@ int main (int argc, char** argv)
     assert( hcod[0].gete()(hcod[0].where(2),0) == 3 );
     assert( exitOk );
 
-    hcod.downdate( 0,hcod[0].where(NR[0]-1) );
+    hcod.downdate( 0,(unsigned int)hcod[0].where(NR[0]-1) );
     exitOk&=hcod.testRecomposition(&std::cout);
     assert( hcod.rank()==7 );       assert( hcod[0].rank()==2 );
     assert( hcod[1].rank()==3 );    assert( hcod[2].rank()==2 );
     assert( exitOk );
 
-    hcod.downdate( 1,hcod[1].where(NR[1]-1) );
+    hcod.downdate( 1,(unsigned int)hcod[1].where(NR[1]-1) );
     exitOk&=hcod.testRecomposition(&std::cout);
     assert( hcod.rank()==7 );       assert( hcod[0].rank()==2 );
     assert( hcod[1].rank()==2 );    assert( hcod[2].rank()==3 );
@@ -774,7 +795,7 @@ int main (int argc, char** argv)
     assert(hcod.rank()==5);          assert( hcod[0].rank()==3 );
     assert( hcod[1].rank()==1 );    assert( hcod[2].rank()==1 );
 
-    hcod.downdate( 2,hcod[2].where(2) );
+    hcod.downdate( 2,(unsigned int)hcod[2].where(2) );
     exitOk&=hcod.testRecomposition(&std::cout);
     assert(hcod.rank()==4);          assert( hcod[0].rank()==3 );
     assert( hcod[1].rank()==1 );    assert( hcod[2].rank()==0 );
@@ -817,7 +838,7 @@ int main (int argc, char** argv)
     assert(hcod.rank()==7);          assert( hcod[0].rank()==3 );
     assert( hcod[1].rank()==1 );    assert( hcod[2].rank()==3 );
 
-    hcod.downdate( 1,hcod[1].where(NR[1]-1) );
+    hcod.downdate( 1,(unsigned int)hcod[1].where(NR[1]-1) );
     assert(hcod.rank()==6);          assert( hcod[0].rank()==3 );
     assert( hcod[1].rank()==0 );    assert( hcod[2].rank()==3 );
 

--- a/unitTesting/trandom.cpp
+++ b/unitTesting/trandom.cpp
@@ -61,7 +61,7 @@ namespace DummyActiveSet
 		       std::vector<VectorXd> /*e*/,
 		       double /*damping*/ = 0.0)
   {
-     const unsigned int NC = J[0].cols();
+    const unsigned int NC = (unsigned int)J[0].cols();
      VectorXd u = VectorXd::Zero(NC);
 
 /*    MatrixXd Pa = MatrixXd::Identity(NC,NC);
@@ -170,7 +170,7 @@ namespace DummyActiveSet
 		       const double damping = 0.0 )
   {
     /* Build the SOT problem. */
-    const unsigned int NC = Jref[0].cols();
+    const unsigned int NC = (unsigned int)Jref[0].cols();
     std::vector<Eigen::MatrixXd> Jsot(Jref.size());
     std::vector<VectorXd> esot(Jref.size());
     for( unsigned int i=0;i<Jref.size();++i )
@@ -178,7 +178,7 @@ namespace DummyActiveSet
 	MatrixXd& J = Jsot[i]; VectorXd& e= esot[i];
 	const std::vector<int> & Aset = active[i];
 	const std::vector<Bound::bound_t> & Bset = bounds[i];
-	const unsigned int NR = Aset.size();
+	const unsigned int NR = (unsigned int)Aset.size();
 
 	J.resize(NR,NC); e.resize(NR);
 	for( unsigned int r=0;r<NR;++r )
@@ -311,7 +311,7 @@ namespace DummyActiveSet
     int nbConstraint = 0; nr.resize(bref.size());
     for( unsigned int i=0;i<bref.size();++i )
       {
-	nr[i]=bref[i].size();
+	nr[i]=(int)bref[i].size();
 	for( int r = 0;r<bref[i].size();++r )
 	  if(bref[i][r].getType() != Bound::BOUND_TWIN)
 	    nbConstraint ++;
@@ -450,7 +450,7 @@ int main (int argc, char** argv)
       /* Initialize the seed. */
       struct timeval tv;
       gettimeofday(&tv,NULL);
-      int seed = tv.tv_usec % 7919; //= 7594;
+      int seed = int(tv.tv_usec % 7919); //= 7594;
       if( optionMap.count("seed") ) { seed = optionMap["seed"].as<int>(); }
       std::cout << "seed = " << seed << std::endl;
       soth::Random::setSeed(seed);

--- a/unitTesting/tsubmatrix.cpp
+++ b/unitTesting/tsubmatrix.cpp
@@ -17,7 +17,7 @@ void testPermutedBasic()
 {
   MatrixXi m(4,5);
   Map<MatrixXi> map(m.data(), m.size(), 1);
-  map = VectorXi::LinSpaced(m.size(), 0, m.size()-1);
+  map = VectorXi::LinSpaced(m.size(), 0, (int) m.size()-1);
   std::cout << "original matrix:" << std::endl << std::endl;
   std::cout << m << std::endl;
 
@@ -144,7 +144,7 @@ void testDoublePerm()
 
   MatrixXi m(4,5);
   Map<MatrixXi> map(m.data(), m.size(), 1);
-  map = VectorXi::LinSpaced(m.size(), 0, m.size()-1);
+  map = VectorXi::LinSpaced((int) m.size(), 0,(int)(m.size()-1));
   std::cout << "original matrix:" << std::endl << std::endl;
   std::cout << m << std::endl;
 
@@ -192,7 +192,7 @@ void speedTest()
       dummy += C1(0,0);
     }
     stop = clock();
-    total = static_cast<double>(stop-start)/(CLOCKS_PER_SEC*N)*1000;
+    total = static_cast<double>((stop-start)/(CLOCKS_PER_SEC*N)*1000);
     std::cout << "normal mult    : " << total  << "ms" << std::endl;
 
     dummy = 0;
@@ -203,7 +203,7 @@ void speedTest()
       dummy += C2(0,0);
     }
     stop = clock();
-    total = static_cast<double>(stop-start)/(CLOCKS_PER_SEC*N)*1000;
+    total = static_cast<double>((stop-start)/(CLOCKS_PER_SEC*N)*1000);
     std::cout << "Perm*Normal    : " << total  << "ms" << std::endl;
 
     dummy = 0;
@@ -214,7 +214,7 @@ void speedTest()
       dummy += C3(0,0);
     }
     stop = clock();
-    total = static_cast<double>(stop-start)/(CLOCKS_PER_SEC*N)*1000;
+    total = static_cast<double>((stop-start)/(CLOCKS_PER_SEC*N)*1000);
     std::cout << "RowPerm*Normal : " << total  << "ms" << std::endl;
 
     dummy = 0;
@@ -225,7 +225,7 @@ void speedTest()
       dummy += C4(0,0);
     }
     stop = clock();
-    total = static_cast<double>(stop-start)/(CLOCKS_PER_SEC*N)*1000;
+    total = static_cast<double>((stop-start)/(CLOCKS_PER_SEC*N)*1000);
     std::cout << "ColPerm*Normal : " << total  << "ms" << std::endl;
 
     std::cout << std::endl;
@@ -237,7 +237,7 @@ void testCol()
   VectorXi row(3); row << 2,3,0;
   MatrixXi m(4,5);
   Map<MatrixXi> map(m.data(), m.size(), 1);
-  map = VectorXi::LinSpaced(m.size(), 0, m.size()-1);
+  map = VectorXi::LinSpaced((int)m.size(), 0, (int)(m.size()-1));
 
   MatrixXi::ColXpr m1 = m.col(1);
   SubMatrix< MatrixXi::ColXpr,RowPermutation > m1i( m1,row );
@@ -257,12 +257,12 @@ void testStack()
 {
   MatrixXi m1(4,5);
   Map<MatrixXi> map1(m1.data(), m1.size(), 1);
-  map1 = VectorXi::LinSpaced(m1.size(), 0, m1.size()-1);
+  map1 = VectorXi::LinSpaced((int)m1.size(), 0, (int)(m1.size()-1));
   std::cout << "m1 = " << m1 << std::endl;
 
   MatrixXi m2(2,5);
   Map<MatrixXi> map2(m2.data(), m2.size(), 1);
-  map2 = VectorXi::LinSpaced(m2.size(), 0, m2.size()-1);
+  map2 = VectorXi::LinSpaced((int)m2.size(), 0, (int)(m2.size()-1));
   std::cout << "m2 = " << m2 << std::endl;
 
   StackMatrix<MatrixXi,MatrixXi> m12(m1,m2);
@@ -299,12 +299,12 @@ void testStack()
 
   VectorXd v1(4);
   Map<VectorXd> mapv1(v1.data(), v1.size(), 1);
-  mapv1 = VectorXd::LinSpaced(v1.size(), 0, v1.size()-1);
+  mapv1 = VectorXd::LinSpaced((int)v1.size(), 0, (int)(v1.size()-1));
   std::cout << "v1 = " << v1 << std::endl;
 
   VectorXd v2(2);
   Map<VectorXd> mapv2(v2.data(), v2.size(), 1);
-  mapv2 = VectorXd::LinSpaced(v2.size(), 0, v2.size()-1);
+  mapv2 = VectorXd::LinSpaced(v2.size(), 0, (int)(v2.size()-1));
   std::cout << "v2 = " << v2 << std::endl;
 
   SubVectorXd v1i( v1,row1 );

--- a/unitTesting/ttrack.cpp
+++ b/unitTesting/ttrack.cpp
@@ -39,7 +39,8 @@ namespace soth
   };
   double operator-( const Now& t1, const Now& t0 )
   {
-    return (t1.sec-t0.sec)*1000.0 + (t1.usec-t0.usec+0.0)/1000.0;
+    return (double)(t1.sec-t0.sec)*1000.0 + 
+      (double)(t1.usec-t0.usec+0.0)/1000.0;
   }
   std::ostream& operator<< (std::ostream& os,const Now& now )
   { return os << now.sec <<"' " << now.usec;  }
@@ -165,7 +166,7 @@ int main (int argc, char** argv)
   /* Initialize the seed. */
   struct timeval tv;
   gettimeofday(&tv,NULL);
-  int seed = tv.tv_usec % 7919; //= 7594;
+  int seed = (int)(tv.tv_usec % 7919); //= 7594;
   if( argc == 2 )
     {  seed = atoi(argv[1]);  }
   std::cout << "seed = " << seed << std::endl;


### PR DESCRIPTION
This pull request allows compiling on 14.04 LTS. It hopefully keeps backward compatibility by testing eigen version. It also removes numerous warnings making bug fixing easier. Deprecated messages still appear related to boost::signals (version 2 should be ported). Test on DEBUG and RELEASE are still failing.
DEBUG:
         3 - tstage (OTHER_FAULT)
	  5 - thcod (OTHER_FAULT)
	  6 - texhcod (OTHER_FAULT)
	  9 - trandom (OTHER_FAULT)
	 10 - tcod (OTHER_FAULT)
	 11 - ttrack (OTHER_FAULT)
RELEASE:
         6 - texhcod (SEGFAULT)

